### PR TITLE
Performance improvement using left-leaning red-black trees

### DIFF
--- a/list.go
+++ b/list.go
@@ -1,9 +1,11 @@
 package shortcut
 
 import (
+	"bytes"
+	"fmt"
 	"net"
 
-	"github.com/armon/go-radix"
+	"github.com/petar/GoLLRB/llrb"
 
 	"github.com/getlantern/golog"
 )
@@ -12,35 +14,89 @@ var (
 	log = golog.LoggerFor("shortcut")
 )
 
-type radixList struct {
-	root *radix.Tree
+type ipList struct {
+	root *llrb.LLRB
 }
 
-// newRadixList creates a shortcut list from a list of CIDR subnets in "a.b.c.d/24"
-// form.
-func newRadixList(subnets []string) *radixList {
-	tree := radix.New()
+type entry struct {
+	ipnet *net.IPNet
+}
+
+func (a *entry) Less(b llrb.Item) bool {
+	ipa := a.ipnet.IP
+	ipb := b.(*entry).ipnet.IP
+	return bytes.Compare(ipa, ipb) < 0
+}
+
+func (a *entry) String() string {
+	return a.ipnet.String()
+}
+
+// newipList creates a shortcut list from a list of CIDR subnets in "a.b.c.d/24"
+// form, inspired by discussion at
+// http://stackoverflow.com/questions/13875486/how-to-sort-ip-addresses-in-a-trie-table
+func newIPList(subnets []string) (*ipList, error) {
+	tree := llrb.New()
 	for _, s := range subnets {
-		_, n, err := net.ParseCIDR(s)
+		_, ipnet, err := net.ParseCIDR(s)
 		if err != nil {
 			log.Debugf("Skip %s: %v", s, err)
 			continue
 		}
-		_, _ = tree.Insert(string(n.IP), n.Mask)
+		ipnet.IP = normalize(ipnet.IP)
+		tree.InsertNoReplace(&entry{ipnet})
 	}
-	return &radixList{tree}
+
+	// Sanity check for overlap
+	detectedOverlap := false
+	var overlapError error
+	tree.DescendLessOrEqual(&entry{
+		&net.IPNet{
+			IP: net.IP([]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}),
+		},
+	}, func(i llrb.Item) bool {
+		e := i.(*entry)
+		ip := e.ipnet.IP
+		first := true
+		tree.DescendLessOrEqual(e, func(i llrb.Item) bool {
+			if first {
+				// Ignore the first, since it will same as pivot
+				first = false
+				return true
+			}
+			if i.(*entry).ipnet.Contains(ip) {
+				detectedOverlap = true
+				overlapError = fmt.Errorf("Overlapping ip ranges detected, %v contains %v", i, ip)
+				return false
+			}
+			return true
+		})
+		return !detectedOverlap
+	})
+
+	if detectedOverlap {
+		return nil, overlapError
+	}
+
+	return &ipList{tree}, nil
 }
 
 // Contains checks if the ip belongs to one of the subnet in the list.
-func (l *radixList) Contains(ip net.IP) bool {
+func (l *ipList) Contains(ip net.IP) bool {
+	ip = normalize(ip)
+	e := &entry{
+		&net.IPNet{
+			IP: ip,
+		},
+	}
 	found := false
-	l.root.Walk(func(s string, v interface{}) bool {
-		ipnet := net.IPNet{net.IP(s), v.(net.IPMask)}
-		if ipnet.Contains(ip) {
-			found = true
-			return true
-		}
-		return false // continue walk
+	l.root.DescendLessOrEqual(e, func(i llrb.Item) bool {
+		found = i.(*entry).ipnet.Contains(ip)
+		return false
 	})
 	return found
+}
+
+func normalize(ip net.IP) net.IP {
+	return ip.To16()
 }

--- a/list_test.go
+++ b/list_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestContains(t *testing.T) {
-	l := newRadixList([]string{
+	l, err := newIPList([]string{
 		"1.0.1.0/24",
 		"1.0.2.0/23",
 		"1.0.8.0/21",
@@ -22,6 +22,10 @@ func TestContains(t *testing.T) {
 		"1.1.10.0/23",
 		"2001:230:8000::/33",
 	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
 	assert.True(t, l.Contains(net.ParseIP("1.0.1.9")))
 	assert.True(t, l.Contains(net.ParseIP("1.0.3.9")))
 	assert.False(t, l.Contains(net.ParseIP("1.0.4.9")))
@@ -30,9 +34,17 @@ func TestContains(t *testing.T) {
 	assert.False(t, l.Contains(net.ParseIP("2001:230:4001::")))
 }
 
-func BenchmarkFindWithRadix(b *testing.B) {
+func TestOverlap(t *testing.T) {
+	_, err := newIPList([]string{"1.0.1.0/24", "1.0.1.5/24"})
+	assert.Error(t, err)
+}
+
+func BenchmarkContains(b *testing.B) {
 	f, _ := os.Open("test_list.txt")
-	l := newRadixList(readLines(f))
+	l, err := newIPList(readLines(f))
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/shortcut_test.go
+++ b/shortcut_test.go
@@ -8,10 +8,13 @@ import (
 )
 
 func TestAllow(t *testing.T) {
-	s := NewFromReader(
+	s, err := NewFromReader(
 		strings.NewReader("127.0.0.0/24\n8.8.0.0/16\n"),
 		strings.NewReader("fe80::1/64\n::/64\n"),
 	)
+	if !assert.NoError(t, err) {
+		return
+	}
 	assert.True(t, s.Allow("127.0.0.1:8888"))
 	assert.True(t, s.Allow("localhost:8888"))
 	assert.True(t, s.Allow("localhost"))


### PR DESCRIPTION
This improves performance considerably, on the assumption that the IP ranges are non-overlapping.

Before:

```
BenchmarkFindWithRadix-4   	    3000	    547908 ns/op
```

After:

```
BenchmarkContains-4   	 2000000	       995 ns/op
```