### PR TITLE
Add known ranges that should always be proxied

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
+[![Go](https://github.com/getlantern/shortcut/actions/workflows/go.yml/badge.svg)](https://github.com/getlantern/shortcut/actions/workflows/go.yml)
 # shortcut
-Bypass proxying if the target address belongs to territory specific network segments
+Provides the ability to check if target address belongs to IP ranges known to be unblocked, in which case there is the possibility to send 
+traffic directly. Alternatively or in addition, include IP ranges known to be blocked or to indicate DNS poisoning.

--- a/shortcut.go
+++ b/shortcut.go
@@ -1,6 +1,7 @@
-// package shortcut constructs a dialer with IPv4 and IPv6 subnets. When the
-// address to dial belongs to one of the subnets, it dial via the direct
-// dialer, i.e., the shortcut, and dial the proxiedDialer otherwise.
+// package shortcut determines whether traffic should be routed directly, should
+// be proxied, or whether the routing is unknown based on matching (or not)
+// known IP ranges for DNS poisoned IP ranges in specific countries, for
+// example.
 
 package shortcut
 
@@ -11,24 +12,39 @@ import (
 	"net"
 )
 
+type Method int
+
+const (
+	// Indicates traffic to this domain/IP should be proxied.
+	Proxy Method = iota
+
+	// Indicates traffic to this domain/IP should be routed directly.
+	Direct
+
+	// Indicates shortcut has no opinion about the routing for this domain/IP.
+	Unknown
+)
+
 type Shortcut interface {
-	// Allow checks if the address is allowed to use shortcut and returns true
-	// together with the resolved IP address if so.
-	Allow(ctx context.Context, addr string) (bool, net.IP)
+	// RouteMethod checks if the address should be routed directly or should
+	// be proxied, or whether the ideal method is unknown.
+	RouteMethod(ctx context.Context, addr string) (Method, net.IP)
 	// SetResolver sets a custom resolver to replace the system default.
 	SetResolver(r func(ctx context.Context, addr string) (net.IP, error))
 }
 
 type shortcut struct {
-	v4list   *SortList
-	v6list   *SortList
-	resolver func(ctx context.Context, addr string) (net.IP, error)
+	v4DirectList *SortList
+	v6DirectList *SortList
+	v4ProxyList  *SortList
+	v6ProxyList  *SortList
+	resolver     func(ctx context.Context, addr string) (net.IP, error)
 }
 
 // NewFromReader is a helper to create shortcut from readers. The content
 // should be in CIDR format, one entry per line.
-func NewFromReader(v4 io.Reader, v6 io.Reader) Shortcut {
-	return New(readLines(v4), readLines(v6))
+func NewFromReader(v4Direct, v6Direct, v4Proxy, v6Proxy io.Reader) Shortcut {
+	return New(readLines(v4Direct), readLines(v6Direct), readLines(v4Proxy), readLines(v6Proxy))
 }
 
 func readLines(r io.Reader) []string {
@@ -41,16 +57,20 @@ func readLines(r io.Reader) []string {
 	return lines
 }
 
-// New creates a new shortcut from the subnets.
-func New(ipv4Subnets []string, ipv6Subnets []string) Shortcut {
-	log.Debugf("Creating shortcut with %d ipv4 subnets and %d ipv6 subnets",
-		len(ipv4Subnets),
-		len(ipv6Subnets),
+// New creates a new shortcut from the subnets for both direct and proxied traffic.
+func New(ipv4DirectSubnets, ipv6DirectSubnets, ipv4ProxySubnets, ipv6ProxySubnets []string) Shortcut {
+	log.Debugf("Creating shortcut with direct %d ipv4 subnets and %d ipv6 subnets and proxied %d ipv4 subnets and %d ipv6 subnets",
+		len(ipv4DirectSubnets),
+		len(ipv6DirectSubnets),
+		len(ipv4ProxySubnets),
+		len(ipv6ProxySubnets),
 	)
 	return &shortcut{
-		v4list:   NewSortList(ipv4Subnets),
-		v6list:   NewSortList(ipv6Subnets),
-		resolver: defaultResolver,
+		v4DirectList: NewSortList(ipv4DirectSubnets),
+		v6DirectList: NewSortList(ipv6DirectSubnets),
+		v4ProxyList:  NewSortList(ipv4ProxySubnets),
+		v6ProxyList:  NewSortList(ipv6ProxySubnets),
+		resolver:     defaultResolver,
 	}
 }
 
@@ -78,16 +98,26 @@ func (s *shortcut) SetResolver(r func(ctx context.Context, addr string) (net.IP,
 	s.resolver = r
 }
 
-func (s *shortcut) Allow(ctx context.Context, addr string) (bool, net.IP) {
+func (s *shortcut) RouteMethod(ctx context.Context, addr string) (Method, net.IP) {
 	ip, err := s.resolver(ctx, addr)
 	if err != nil {
-		return false, nil
+		return Unknown, nil
 	}
 	if ip4 := ip.To4(); ip4 != nil {
-		return s.v4list.Contains(ip), ip
+		return s.check(s.v4DirectList, s.v4ProxyList, ip)
 	}
 	if ip6 := ip.To16(); ip6 != nil {
-		return s.v6list.Contains(ip), ip
+		return s.check(s.v6DirectList, s.v6ProxyList, ip)
 	}
-	return false, nil
+	return Unknown, ip
+}
+
+func (s *shortcut) check(direct, proxy *SortList, ip net.IP) (Method, net.IP) {
+	if direct.Contains(ip) {
+		return Direct, ip
+	}
+	if proxy.Contains(ip) {
+		return Proxy, ip
+	}
+	return Unknown, ip
 }

--- a/shortcut_test.go
+++ b/shortcut_test.go
@@ -30,9 +30,9 @@ func TestAllow(t *testing.T) {
 	assert.Equal(t, allow("localhost"), Direct)
 	assert.Equal(t, allow("google-public-dns-a.google.com"), Direct)
 	assert.Equal(t, allow("google-public-dns-b.google.com"), Direct)
-	assert.Equal(t, allow("1.2.4.5:8888"), Proxy)
-	assert.Equal(t, allow("1.2.4.5"), Proxy)
-	assert.Equal(t, allow("not-exist.com"), Proxy)
+	assert.Equal(t, allow("1.2.4.5:8888"), Unknown)
+	assert.Equal(t, allow("1.2.4.5"), Unknown)
+	assert.Equal(t, allow("not-exist.com"), Unknown)
 
 	// Test DNS poisoned IP for Iran
 	assert.Equal(t, allow("10.10.1.1"), Proxy)
@@ -54,7 +54,7 @@ func TestContext(t *testing.T) {
 	assert.Equal(t, hit, Direct, "host should be allowed when IP is in the list")
 	ctx, _ = context.WithTimeout(ctx, 10*time.Millisecond)
 	hit, _ = s.RouteMethod(ctx, "google-public-dns-a.google.com:8888")
-	assert.Equal(t, hit, Proxy, "host should be disallowed if context exceeded performing DNS lookup")
+	assert.Equal(t, hit, Unknown, "host should be disallowed if context exceeded performing DNS lookup")
 }
 
 func TestSystemResolverTiming(t *testing.T) {


### PR DESCRIPTION
This adds the ability to include a proxied IP range in addition to the direct IP range for things like "scenic routing" described in https://github.com/getlantern/lantern-internal/issues/5044