### PR TITLE
Fix IPs passed to lists

### DIFF
--- a/list_test.go
+++ b/list_test.go
@@ -21,6 +21,7 @@ func TestContains(t *testing.T) {
 		"1.0.2.0/23",
 		"1.0.8.0/21",
 		"1.0.32.0/19",
+		"10.0.0.0/8",
 	})
 	// smaller than the smallest network
 	assert.False(t, l.Contains(net.ParseIP("1.0.0.254").To4()))
@@ -36,6 +37,7 @@ func TestContains(t *testing.T) {
 	assert.True(t, l.Contains(net.ParseIP("1.1.11.254").To4()))
 	// larger than the largest network
 	assert.False(t, l.Contains(net.ParseIP("1.1.16.1").To4()))
+	assert.True(t, l.Contains(net.ParseIP("10.10.1.1").To4()))
 
 	l = NewSortList([]string{
 		"fe80::1/64",

--- a/shortcut.go
+++ b/shortcut.go
@@ -104,10 +104,10 @@ func (s *shortcut) RouteMethod(ctx context.Context, addr string) (Method, net.IP
 		return Unknown, nil
 	}
 	if ip4 := ip.To4(); ip4 != nil {
-		return s.check(s.v4DirectList, s.v4ProxyList, ip)
+		return s.check(s.v4DirectList, s.v4ProxyList, ip4)
 	}
 	if ip6 := ip.To16(); ip6 != nil {
-		return s.check(s.v6DirectList, s.v6ProxyList, ip)
+		return s.check(s.v6DirectList, s.v6ProxyList, ip6)
 	}
 	return Unknown, ip
 }

--- a/shortcut_test.go
+++ b/shortcut_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAllow(t *testing.T) {
 	s := NewFromReader(
-		strings.NewReader("127.0.0.0/24\n8.8.0.0/16\n"),
+		strings.NewReader("127.0.0.0/24\n8.8.0.0/16\n10.11.0.0/16\n"),
 		strings.NewReader("fe80::1/64\n::/64\n2001:4860:4860::8800/120\n"),
 		strings.NewReader("10.10.0.0/16\n"),
 		strings.NewReader(""),
@@ -36,6 +36,8 @@ func TestAllow(t *testing.T) {
 
 	// Test DNS poisoned IP for Iran
 	assert.Equal(t, allow("10.10.1.1"), Proxy)
+
+	assert.Equal(t, allow("10.11.1.1"), Direct)
 }
 
 func TestContext(t *testing.T) {


### PR DESCRIPTION
This fixes https://github.com/getlantern/lantern-internal/issues/5054, ensuring the addresses are of the proper format regardless of what is passed in.